### PR TITLE
provisioners/ansible_local: fix #6763

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ BUG FIXES:
       galaxy resources when running on a Windows host [GH-6740, GH-6757]
   - provisioners/ansible_local: Change the way to verify `ansible-galaxy`
       presence, to avoid a non-zero status code with Ansible 2.0 [GH-6793]
+  - provisioners/ansible_local: The configuration sanity checks now only warn
+      on missing files or directories, so that the requested vagrant command is
+      always executed (e.g. `vagrant destroy` is not aborted when the configured
+      playbook is not present on the guest) [GH-6763]
 
 ## 1.8.1 (December 21, 2015)
 

--- a/plugins/provisioners/ansible/config/guest.rb
+++ b/plugins/provisioners/ansible/config/guest.rb
@@ -41,12 +41,14 @@ module VagrantPlugins
 
           if machine.communicate.ready? && !machine.communicate.test("test #{test_args} #{remote_path}")
             if error_message_key
-              @errors << I18n.t(error_message_key, path: remote_path, system: "guest")
+              # only show warnings, as raising an error would abort the request
+              # vagrant action (e.g. prevent `destroy` to be executed)
+              machine.ui.warn(I18n.t(error_message_key, path: remote_path, system: "guest"))
             end
             return false
           end
           # when the machine is not ready for SSH communication,
-          # the check is "optimistically" by passed.
+          # the check is "optimistically" bypassed.
           true
         end
 


### PR DESCRIPTION
Before this change, the detection of a non-existing path on the guest
machine was considered as an error and lead to interrupt the current vagrant
action. This was actually a mistake to do so, since the config checks
are performed before many other vagrant actions than `provision`.
The config.validate phase is also intended to primarily check the options
sanity, but it cannot be too strict with the guest state (which can easily
get "out of automatic control").

With this change, we still apply these checks (when possible), but only warn
about possible configuration problems. This way, the subsequent
statements will happen anyway (e.g. ansible commands will be
executed, vagrant machine will be destroyed, etc.)